### PR TITLE
Update symfony version to 5.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "require": {
         "php": "~5.6|~7.0",
 
-        "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-        "symfony/config": "~2.8|~3.0|~4.0",
-        "symfony/console": "~2.8|~3.0|~4.0",
-        "symfony/http-kernel": "~2.8|~3.0|~4.0",
-        "symfony/dependency-injection": "~2.8|~3.0|~4.0",
+        "symfony/framework-bundle": "~2.8|~3.0|~4.0|~5.0",
+        "symfony/config": "~2.8|~3.0|~4.0|~5.0",
+        "symfony/console": "~2.8|~3.0|~4.0|~5.0",
+        "symfony/http-kernel": "~2.8|~3.0|~4.0|~5.0",
+        "symfony/dependency-injection": "~2.8|~3.0|~4.0|~5.0",
 
         "doctrine/orm": "~2.5"
     },


### PR DESCRIPTION
Hi,

thank you for this bundle, for now it's little bit outdated and support only symfony 4.*, this PR add support of 5.0+.

Best regards. 